### PR TITLE
Add manifest v2 to the repo

### DIFF
--- a/.stignore
+++ b/.stignore
@@ -1,0 +1,4 @@
+.git
+
+# dlv binary
+__debug_bin

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 [![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/deploy?repository=https://github.com/okteto/go-getting-started)
 
-This example shows how to use [Okteto](https://github.com/okteto/okteto) to develop a Go Sample App directly in Kubernetes. The Go Sample App is deployed using Kubernetes manifests.
+This example shows how to use the [Okteto CLI](https://github.com/okteto/okteto) to develop a Go Sample App directly in Kubernetes. The Go Sample App is deployed using Kubernetes manifests.
 
-This is the application used for the [How to Develop and Debug Go Applications in Kubernetes](https://okteto.com/blog/how-to-develop-go-apps-in-kubernetes/) blog post.
+This is the application used for the [Getting Started on Okteto with Go](https://www.okteto.com/docs/samples/golang/) tutorial.

--- a/k8s.yml
+++ b/k8s.yml
@@ -13,7 +13,7 @@ spec:
         app: hello-world
     spec:
       containers:
-      - image: okteto/hello-world:golang
+      - image: okteto.dev/hello-world:1.0.0
         name: hello-world
 
 ---
@@ -22,12 +22,30 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hello-world
-  annotations:
-    dev.okteto.com/auto-ingress: "true"
 spec:
-  type: ClusterIP  
+  type: ClusterIP
   ports:
   - name: "hello-world"
     port: 8080
   selector:
     app: hello-world
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hello-world
+  annotations:
+    dev.okteto.com/generate-host: hello-world
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          service:
+            name: hello-world
+            port:
+              number: 8080
+        path: /
+        pathType: ImplementationSpecific

--- a/k8s.yml
+++ b/k8s.yml
@@ -13,7 +13,7 @@ spec:
         app: hello-world
     spec:
       containers:
-      - image: okteto.dev/hello-world:1.0.0
+      - image: okteto.dev/go-hello-world:1.0.0
         name: hello-world
 
 ---

--- a/okteto.yml
+++ b/okteto.yml
@@ -1,0 +1,23 @@
+build:
+  hello-world:
+    image: okteto.dev/hello-world:1.0.0
+    context: .
+
+deploy:
+  - kubectl apply -f k8s.yml
+
+dev:
+  hello-world:
+    image: okteto/golang:1
+    command: bash
+    sync:
+      - .:/usr/src/app
+    volumes:
+      - /go
+      - /root/.cache
+    securityContext:
+      capabilities:
+        add:
+          - SYS_PTRACE
+    forward:
+      - 2345:2345

--- a/okteto.yml
+++ b/okteto.yml
@@ -1,6 +1,6 @@
 build:
   hello-world:
-    image: okteto.dev/hello-world:1.0.0
+    image: okteto.dev/go-hello-world:1.0.0
     context: .
 
 deploy:


### PR DESCRIPTION
Our current `okteto init` version doesn't provide an optimal experience yet.
Including the okteto manifest in the getting started repos will help the users to configure their own