### PR TITLE
Add test and okteto test to manifest

### DIFF
--- a/integration/tests.sh
+++ b/integration/tests.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+(
+	# Runs integration tests against a pre deployed instance of this application
+	# We use okteto tests to run this tests so we go through the internal network
+	# and not the ingress
+
+	set -e # make any error fail the script
+	set -u # make unbound variables fail the script
+
+	# SC2039: In POSIX sh, set option pipefail is undefined
+	# shellcheck disable=SC2039
+	set -o pipefail # make any pipe error fail the script
+
+	expected="Hello world!"
+	actual=$(curl -s "http://hello-world.${OKTETO_NAMESPACE}:8080")
+
+	if [ "$actual" != "$expected" ]; then
+		echo "Expected 'Hello world!' but got '$actual'"
+		exit 1
+	fi
+
+	echo "OK"
+)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestServer(t *testing.T) {
+
+	rw := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "", nil)
+
+	helloServer(rw, r)
+
+	if rw.Code != http.StatusOK {
+		t.Fatal("expected 200 status code")
+	}
+
+	if rw.Body.String() != "Hello world!" {
+		t.Fatal(`invalid response. Expected: "Hello world!"`)
+	}
+}

--- a/okteto.yml
+++ b/okteto.yml
@@ -1,6 +1,16 @@
 deploy:
   - kubectl apply -f k8s.yml
 
+test:
+  unit:
+    image: okteto/golang:1
+    commands:
+      - "go test . -v"
+  integration:
+    context: integration
+    commands:
+      - "./tests.sh"
+
 dev:
   hello-world:
     image: okteto/golang:1


### PR DESCRIPTION
Add integration and unit tests through `okteto test`. Requires https://github.com/okteto/okteto/pull/4250

NOTE: This will work only with CLI `2.27.x` Do not merge until we release that versions (we are currently at 2.26)

