### PR TITLE
Mejoras para desarrollo con Okteto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM golang:buster
 
 WORKDIR /app
+COPY go.mod go.mod
+RUN go mod download && go mod verify
+
 ADD . .
-RUN go build -o /usr/local/bin/hello-world
+RUN go mod tidy && go build -o /usr/local/bin/hello-world
 
 EXPOSE 8080
 CMD ["/usr/local/bin/hello-world"]

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/okteto/go-getting-started
 
 go 1.19
+
+require (
+        github.com/prometheus/client_golang v1.16.0
+)

--- a/k8s.yml
+++ b/k8s.yml
@@ -3,7 +3,12 @@ kind: Deployment
 metadata:
   name: hello-world
 spec:
-  replicas: 1
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: hello-world
@@ -13,8 +18,19 @@ spec:
         app: hello-world
     spec:
       containers:
-      - image: okteto/go-getting-started:hello-world
+      - image: $OKTETO_BUILD_HELLO_WORLD_IMAGE
         name: hello-world
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 2
+          successThreshold: 1
+          failureThreshold: 3
 
 ---
 

--- a/main.go
+++ b/main.go
@@ -1,18 +1,58 @@
 package main
 
 import (
-	"fmt"
-	"net/http"
+        "fmt"
+        "net/http"
+
+        "github.com/prometheus/client_golang/prometheus"
+        "github.com/prometheus/client_golang/prometheus/promauto"
+        "github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+        // Contador para las llamadas al endpoint de health
+        healthCheckCounter = promauto.NewCounter(prometheus.CounterOpts{
+                Name: "hello_world_health_checks_total",
+                Help: "El número total de veces que se ha llamado al endpoint de health",
+        })
 )
 
 func main() {
-	fmt.Println("Starting hello-world server...")
-	http.HandleFunc("/", helloServer)
-	if err := http.ListenAndServe(":8080", nil); err != nil {
-		panic(err)
-	}
+        fmt.Println("Starting hello-world server...")
+        
+        // Configurar rutas
+        http.HandleFunc("/", helloServer)
+        http.HandleFunc("/health", healthServer)
+        
+        // Exponer métricas de Prometheus en /metrics
+        http.Handle("/metrics", promhttp.Handler())
+        
+        fmt.Println("Server listening on :8080")
+        fmt.Println("Metrics available at /metrics")
+        fmt.Println("Health endpoint at /health")
+        
+        if err := http.ListenAndServe(":8080", nil); err != nil {
+                panic(err)
+        }
 }
 
 func helloServer(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprint(w, "Hello world!")
+        message := `
+        ¡Desarrollar con Okteto es increíble! 🚀
+        
+        Hot reloading, entornos de desarrollo en la nube,
+        y despliegues instantáneos hacen que el desarrollo
+        sea más rápido y divertido que nunca.
+        
+        ¡Okteto mola muchísimo! 😎
+        `
+        fmt.Fprint(w, message)
+}
+
+func healthServer(w http.ResponseWriter, r *http.Request) {
+        // Incrementar el contador cada vez que se llama al endpoint de health
+        healthCheckCounter.Inc()
+        
+        w.WriteHeader(http.StatusOK)
+        fmt.Fprint(w, "OK")
 }

--- a/okteto.yml
+++ b/okteto.yml
@@ -1,5 +1,10 @@
+build:
+  hello-world:
+    context: .
+    dockerfile: Dockerfile
+
 deploy:
-  - kubectl apply -f k8s.yml
+  - envsubst < k8s.yml | kubectl apply -f -
 
 dev:
   hello-world:


### PR DESCRIPTION
# Mejoras para desarrollo con Okteto

## Resumen de cambios

Esta PR implementa varias mejoras para el desarrollo con Okteto:

### 1. Mensaje personalizado
- Se modificó el mensaje principal para mostrar un texto cool sobre cómo mola desarrollar con Okteto

### 2. Endpoint de health
- Se añadió un endpoint `/health` que devuelve "OK" cuando la aplicación está funcionando correctamente
- Este endpoint es utilizado por el readiness probe para verificar el estado de la aplicación

### 3. Readiness Probe
- Se configuró un readiness probe que verifica el endpoint `/health` cada 10 segundos
- Esto asegura que el tráfico solo se dirija a los pods que están listos para recibir solicitudes

### 4. Rolling Update
- Se cambió la estrategia de despliegue a RollingUpdate con maxSurge=1 y maxUnavailable=0
- Esto permite actualizaciones sin tiempo de inactividad
- Se aumentó el número de réplicas a 2 para tener alta disponibilidad durante las actualizaciones

### 5. Métricas de Prometheus
- Se añadió una métrica de Prometheus que cuenta las veces que se llama al endpoint `/health`
- La métrica se expone en el endpoint `/metrics` para que pueda ser consumida por Prometheus
- Se actualizó el Dockerfile para manejar correctamente las dependencias de Go

### 6. Mejoras en el despliegue
- Se modificó el archivo okteto.yml para usar `envsubst` en el comando de despliegue
- Esto permite que las variables de entorno se expandan correctamente en el archivo k8s.yml

## Beneficios

Estas mejoras hacen que la aplicación sea más robusta y esté mejor preparada para entornos de producción:

- El endpoint de health permite monitorear el estado de la aplicación
- El readiness probe asegura que solo los pods saludables reciban tráfico
- La estrategia de rolling update permite actualizaciones sin tiempo de inactividad
- Las métricas de Prometheus permiten monitorear la actividad de health checks

## Cómo probar

Para probar estos cambios:

1. Desplegar la aplicación con `okteto deploy`
2. Verificar el endpoint principal: `/`
3. Verificar el endpoint de health: `/health`
4. Verificar las métricas de Prometheus: `/metrics`
5. Hacer varias llamadas al endpoint de health y verificar que el contador aumenta